### PR TITLE
feat(schematics): add Local Component State

### DIFF
--- a/docs/docs/angular/schematics.mdx
+++ b/docs/docs/angular/schematics.mdx
@@ -94,6 +94,21 @@ Alias:
 ng g @datorama/akita:ahes todos
 ```
 
+### Generate a Local Component State
+```bash
+ng g @datorama/akita:component-state todos
+
+Alias:
+ng g @datorama/akita:cs todos
+
+Options:
+  --type="providers" / "factory" / "service" // default: providers decides what type of local component state to generate
+```
+
+:::tip
+Type *providers*: refers to adding the state to the component providers array individually, *factory*: a single factory to the component providers array and *service*: as a standard service. See the [Local Component State docs](local-state) for more info.
+:::
+
 ### Generate Tests
 Add the `--spec` option. For example:
 

--- a/libs/akita-schematics/src/collection.json
+++ b/libs/akita-schematics/src/collection.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "@schematics/angular"
-  ],
+  "extends": ["@schematics/angular"],
   "schematics": {
     "ng-add": {
       "description": "Akita schematic",
@@ -9,73 +7,61 @@
       "factory": "./ng-add/index#akitaNgAdd"
     },
     "feature": {
-      "aliases": [
-        "af"
-      ],
+      "aliases": ["af"],
       "factory": "./ng-g/feature",
       "schema": "./ng-g/feature/schema.json",
       "description": "Add feature state"
     },
     "store": {
-      "aliases": [
-        "as"
-      ],
+      "aliases": ["as"],
       "description": "A store",
       "factory": "./ng-g/store/index",
       "schema": "./ng-g/store/schema.json"
     },
     "query": {
-      "aliases": [
-        "aq"
-      ],
+      "aliases": ["aq"],
       "description": "A query",
       "factory": "./ng-g/query/index",
       "schema": "./ng-g/query/schema.json"
     },
+    "component-state": {
+      "aliases": ["cs"],
+      "description": "A local component state",
+      "factory": "./ng-g/component-state/index",
+      "schema": "./ng-g/component-state/schema.json"
+    },
     "entity-store": {
-      "aliases": [
-        "aes"
-      ],
+      "aliases": ["aes"],
       "description": "An entity store",
       "factory": "./ng-g/entity-store/index",
       "schema": "./ng-g/entity-store/schema.json"
     },
     "entity-query": {
-      "aliases": [
-        "aeq"
-      ],
+      "aliases": ["aeq"],
       "description": "An entity query",
       "factory": "./ng-g/entity-query/index",
       "schema": "./ng-g/entity-query/schema.json"
     },
     "http-entity-service": {
-      "aliases": [
-        "ahes"
-      ],
+      "aliases": ["ahes"],
       "description": "An http entity service",
       "factory": "./ng-g/http-entity-service/index",
       "schema": "./ng-g/http-entity-service/schema.json"
     },
     "firebase-entity-service": {
-      "aliases": [
-        "afes"
-      ],
+      "aliases": ["afes"],
       "description": "An Firebase entity service",
       "factory": "./ng-g/firebase-entity-service/index",
       "schema": "./ng-g/firebase-entity-service/schema.json"
     },
     "model": {
-      "aliases": [
-        "am"
-      ],
+      "aliases": ["am"],
       "description": "A model",
       "factory": "./ng-g/model/index",
       "schema": "./ng-g/model/schema.json"
     },
     "akita-service": {
-      "aliases": [
-        "asr"
-      ],
+      "aliases": ["asr"],
       "description": "A service",
       "factory": "./ng-g/service/index",
       "schema": "./ng-g/service/schema.json"
@@ -91,9 +77,7 @@
       "schema": "./ng-g/component/schema.json"
     },
     "effect": {
-      "aliases": [
-        "aef"
-      ],
+      "aliases": ["aef"],
       "description": "A effect",
       "factory": "./ng-g/effect/index",
       "schema": "./ng-g/effect/schema.json"

--- a/libs/akita-schematics/src/ng-g/component-state/files/factory/__name@dasherize__.state.spec.ts
+++ b/libs/akita-schematics/src/ng-g/component-state/files/factory/__name@dasherize__.state.spec.ts
@@ -1,0 +1,14 @@
+import { ComponentState, componentStateFactory  } from './<%= dasherize(name) %>.state';
+
+describe('ComponentState', () => {
+  let componentState: ComponentState;
+
+  beforeEach(() => {
+    componentState = componentStateFactory(undefined);
+  });
+
+  it('should create an instance', () => {
+    expect(componentState).toBeTruthy();
+  });
+
+});

--- a/libs/akita-schematics/src/ng-g/component-state/files/factory/__name@dasherize__.state.ts
+++ b/libs/akita-schematics/src/ng-g/component-state/files/factory/__name@dasherize__.state.ts
@@ -1,0 +1,19 @@
+import { ActiveState, guid, Query, Store } from '@datorama/akita';
+import { ElementRef } from '@angular/core';
+
+interface <%= classify(name) %>ComponentState extends ActiveState {
+  loading: boolean;
+}
+
+export class ComponentState {
+  store: Store<<%= classify(name) %>ComponentState>;
+  query: Query<<%= classify(name) %>ComponentState>;
+}
+
+export function componentStateFactory(element: ElementRef<Element>): ComponentState {
+  const name = element?.nativeElement?.getAttribute('name') || `<%= classify(name) %>Component-${guid()}`;
+  const store = new Store<<%= classify(name) %>ComponentState>({ loading: false }, { name });
+  const query = new Query<<%= classify(name) %>ComponentState>(store);
+
+  return { store, query };
+}

--- a/libs/akita-schematics/src/ng-g/component-state/files/providers/__name@dasherize__.state.spec.ts
+++ b/libs/akita-schematics/src/ng-g/component-state/files/providers/__name@dasherize__.state.spec.ts
@@ -1,0 +1,30 @@
+import {
+  <%= classify(name) %>ComponentQuery,
+  <%= classify(name) %>ComponentStore,
+} from './<%= dasherize(name) %>.state';
+
+describe('<%= classify(name) %>ComponentStore', () => {
+  let componentStore: <%= classify(name) %>ComponentStore;
+
+  beforeEach(() => {
+    componentStore = new <%= classify(name) %>ComponentStore();
+  });
+
+  it('should create an instance', () => {
+    expect(componentStore).toBeTruthy();
+  });
+
+});
+
+describe('<%= classify(name) %>ComponentQuery', () => {
+  let componentQuery: <%= classify(name) %>ComponentQuery;
+
+  beforeEach(() => {
+    componentQuery = new <%= classify(name) %>ComponentQuery(new <%= classify(name) %>ComponentStore());
+  });
+
+  it('should create an instance', () => {
+    expect(componentQuery ).toBeTruthy();
+  });
+
+});

--- a/libs/akita-schematics/src/ng-g/component-state/files/providers/__name@dasherize__.state.ts
+++ b/libs/akita-schematics/src/ng-g/component-state/files/providers/__name@dasherize__.state.ts
@@ -1,0 +1,17 @@
+import { ActiveState, guid, Query, Store } from '@datorama/akita';
+import { Injectable } from '@angular/core';
+
+export interface <%= classify(name) %>ComponentState extends ActiveState {
+  loading: boolean;
+}
+
+export class <%= classify(name) %>ComponentStore extends Store<<%= classify(name) %>ComponentState> {
+  constructor() {
+    super({ loading: true }, { name: `<%= classify(name) %>Component-${guid()}` });
+  }
+}
+
+@Injectable()
+export class <%= classify(name) %>ComponentQuery extends Query<<%= classify(name) %>ComponentState> {
+  constructor(protected store: <%= classify(name) %>ComponentStore) { super(store); }
+}

--- a/libs/akita-schematics/src/ng-g/component-state/files/service/__name@dasherize__.state.spec.ts
+++ b/libs/akita-schematics/src/ng-g/component-state/files/service/__name@dasherize__.state.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { <%= classify(name) %>ComponentStateService } from './<%= dasherize(name) %>.state';
+
+describe('<%= classify(name) %>ComponentStateService', () => {
+  let service: <%= classify(name) %>ComponentStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(<%= classify(name) %>ComponentStateService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/akita-schematics/src/ng-g/component-state/files/service/__name@dasherize__.state.ts
+++ b/libs/akita-schematics/src/ng-g/component-state/files/service/__name@dasherize__.state.ts
@@ -1,0 +1,31 @@
+import { ActiveState, Query, Store } from '@datorama/akita';
+import { Injectable } from '@angular/core';
+
+interface <%= classify(name) %>ComponentState extends ActiveState {
+  loading: boolean;
+}
+
+class ComponentState {
+  store: Store<<%= classify(name) %>ComponentState>;
+  query: Query<<%= classify(name) %>ComponentState>;
+}
+
+@Injectable({ providedIn: 'root' })
+export class <%= classify(name) %>ComponentStateService {
+
+private stores = new Map<string, ComponentState>();
+
+public createState(name: string): ComponentState {
+    const store = new Store<<%= classify(name) %>ComponentState>({ loading: false }, { name });
+    const query = new Query<<%= classify(name) %>ComponentState>(store);
+
+    const state: ComponentState = { store, query };
+    this.stores.set(name, state);
+
+    return state;
+}
+
+public getState(name: string): ComponentState {
+    return this.stores.get(name);
+  }
+}

--- a/libs/akita-schematics/src/ng-g/component-state/index.ts
+++ b/libs/akita-schematics/src/ng-g/component-state/index.ts
@@ -1,0 +1,24 @@
+import { Rule, apply, branchAndMerge, chain, filter, mergeWith, move, noop, template, url, Tree, SchematicContext } from '@angular-devkit/schematics';
+
+import { getProjectPath, stringUtils, parseName } from '../utils';
+
+export default function (options: any): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    options.path = getProjectPath(host, options);
+
+    const parsedPath = parseName(options);
+    options.name = parsedPath.name;
+    options.path = parsedPath.path;
+
+    const templateSource = apply(url(`./files/${options?.type || 'providers'}`), [
+      options.spec ? noop() : filter((path) => !path.endsWith('.spec.ts')),
+      template({
+        ...stringUtils,
+        ...(options as object),
+      } as any),
+      move(parsedPath.path),
+    ]);
+
+    return chain([branchAndMerge(chain([mergeWith(templateSource)]))])(host, context);
+  };
+}

--- a/libs/akita-schematics/src/ng-g/component-state/schema.json
+++ b/libs/akita-schematics/src/ng-g/component-state/schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsAkitaComponentState",
+  "title": "Akita Component State Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the component.",
+      "type": "string",
+      "alias": "s",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path to create the component.",
+      "visible": false
+    },
+    "spec": {
+      "type": "boolean",
+      "description": "Specifies if a spec file is generated.",
+      "default": false
+    },
+    "flat": {
+      "type": "boolean",
+      "default": false,
+      "description": "Flag to indicate if a dir is created."
+    },
+    "dirName": {
+      "type": "string",
+      "default": "state",
+      "description": "Specifies the name of the generated folder"
+    },
+    "feature": {
+      "type": "boolean",
+      "default": false
+    },
+    "type": {
+      "type": "string",
+      "default": "providers",
+      "description": "Local component state type: providers (default)| factory | service."
+    }
+  },
+  "required": []
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

[Local Component State](https://datorama.github.io/akita/docs/angular/local-state) can be created by hand or copy pasting it from the docs. There are no schematics for that.

~Issue~ Discussion Number: [642](https://github.com/datorama/akita/discussions/642)

## What is the new behavior?

You can create Local Component States in accordance with the docs by using schematics.

```bash
$ yarn ng g @datorama/akita:component-state todos
```

You can specify weather to add to the providers array individually (providers), as a factory (factory) or use a standard service (service) by specifying the `--type` option. Defaults to `providers`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
