### PR TITLE
feat(persist-state): emit store name to the subject after persist is done

### DIFF
--- a/packages/akita/src/lib/persistState.ts
+++ b/packages/akita/src/lib/persistState.ts
@@ -1,4 +1,4 @@
-import { from, isObservable, of, OperatorFunction, ReplaySubject, Subscription } from 'rxjs';
+import { from, isObservable, of, BehaviorSubject, OperatorFunction, ReplaySubject, Subscription } from 'rxjs';
 import { filter, map, skip } from 'rxjs/operators';
 import { setAction } from './actions';
 import { $$addStore, $$deleteStore } from './dispatchers';
@@ -14,9 +14,14 @@ import { HashMap, MaybeAsync } from './types';
 let skipStorageUpdate = false;
 
 const _persistStateInit = new ReplaySubject(1);
+const _persistStateInitedStores = new BehaviorSubject([]);
 
 export function selectPersistStateInit() {
   return _persistStateInit.asObservable();
+}
+
+export function selectPersistStateInitedStores() {
+  return _persistStateInitedStores.asObservable();
 }
 
 export function setSkipStorageUpdate(skip: boolean) {
@@ -239,6 +244,7 @@ export function persistState(params?: Partial<PersistStateParams>): PersistState
     );
 
     _persistStateInit.next(true);
+    _persistStateInitedStores.next(_persistStateInitedStores.getValue().concat([key]));
   });
 
   return {

--- a/packages/akita/src/lib/persistState.ts
+++ b/packages/akita/src/lib/persistState.ts
@@ -14,7 +14,7 @@ import { HashMap, MaybeAsync } from './types';
 let skipStorageUpdate = false;
 
 const _persistStateInit = new ReplaySubject(1);
-const _persistStateInitedStores = new BehaviorSubject([]);
+const _persistStateInitedStores = new BehaviorSubject<string[]>([]);
 
 export function selectPersistStateInit() {
   return _persistStateInit.asObservable();


### PR DESCRIPTION
We can persist many stores using:
{
    provide: 'persistStorage',
    useValue: akitaPersistStorage,
    multi: true
}

This function allows you to determine which store has been initiated

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
