### PR TITLE
Fix return type of NgEntityService.handleError

### DIFF
--- a/packages/ng-entity-service/src/lib/ng-entity.service.ts
+++ b/packages/ng-entity-service/src/lib/ng-entity.service.ts
@@ -350,7 +350,7 @@ export class NgEntityService<S extends EntityState = any> extends EntityService<
     return final;
   }
 
-  protected handleError(method: HttpMethod, error: any, errorMsg?: string): any {
+  protected handleError(method: HttpMethod, error: any, errorMsg?: string): Observable<never> {
     this.dispatchError({
       method,
       errorMsg,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The return type of `NgEntityService.handleError` is incorrectly specified as `any`. This method only ever returns `Observable<never>`, which is the return value of [`rxjs/throwError`.](https://rxjs.dev/api/index/function/throwError). Specifying the type explicitly is important to avoid issues such as the [one described here](https://github.com/ReactiveX/rxjs/issues/3673#issuecomment-392863643).

Issue Number: N/A

## What is the new behavior?

The return type of this method is correctly specified.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
