### PR TITLE
fix(akita): support TS strict mode

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "tasksRunnerOptions": {
     "default": {
       "runner": "nx/tasks-runners/default",
@@ -7,7 +8,6 @@
       }
     }
   },
-  "extends": "nx/presets/npm.json",
   "npmScope": "@datorama",
   "affected": {
     "defaultBase": "master"
@@ -33,6 +33,9 @@
     }
   },
   "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build"]
+    },
     "test": {
       "inputs": ["default", "^default", "{workspaceRoot}/jest.preset.js"]
     },

--- a/packages/akita/src/lib/entityStore.ts
+++ b/packages/akita/src/lib/entityStore.ts
@@ -663,7 +663,7 @@ export class EntityStore<S extends EntityState = any, EntityType = getEntityType
 }
 
 // @internal
-export class EntityUIStore<UIState, DEPRECATED = any> extends EntityStore<UIState> {
+export class EntityUIStore<UIState extends EntityState, DEPRECATED = any> extends EntityStore<UIState> {
   _akitaCreateEntityFn: EntityUICreateFn;
 
   constructor(initialState = {}, storeConfig: Partial<StoreConfigOptions> = {}) {

--- a/packages/akita/src/lib/plugins/dirtyCheck/dirtyCheckPlugin.ts
+++ b/packages/akita/src/lib/plugins/dirtyCheck/dirtyCheckPlugin.ts
@@ -6,6 +6,7 @@ import { isUndefined } from '../../isUndefined';
 import { Query } from '../../query';
 import { QueryEntity } from '../../queryEntity';
 import { AkitaPlugin, Queries } from '../plugin';
+import { EntityState } from '../../types';
 
 type Head<State = any> = State | Partial<State>;
 
@@ -29,7 +30,7 @@ export type DirtyCheckResetParams<StoreState = any> = {
   updateFn?: StoreState | ((head: StoreState, current: StoreState) => any);
 };
 
-export class DirtyCheckPlugin<State = any> extends AkitaPlugin<State> {
+export class DirtyCheckPlugin<State extends EntityState = any> extends AkitaPlugin<State> {
   private head: Head<State>;
   private dirty = new BehaviorSubject(false);
   private subscription: Subscription;

--- a/packages/akita/src/lib/plugins/plugin.ts
+++ b/packages/akita/src/lib/plugins/plugin.ts
@@ -6,10 +6,11 @@ import { toBoolean } from '../toBoolean';
 import { getAkitaConfig } from '../config';
 import { getValue } from '../getValueByString';
 import { setValue } from '../setValueByString';
+import { EntityState } from '../types';
 
-export type Queries<State> = Query<State> | QueryEntity<State>;
+export type Queries<State extends EntityState> = Query<State> | QueryEntity<State>;
 
-export abstract class AkitaPlugin<State = any> {
+export abstract class AkitaPlugin<State extends EntityState = any> {
   protected constructor(protected query: Queries<State>, config?: { resetFn?: Function }) {
     if (config && config.resetFn) {
       if (getAkitaConfig().resettable) {

--- a/packages/akita/src/lib/plugins/stateHistory/stateHistoryPlugin.ts
+++ b/packages/akita/src/lib/plugins/stateHistory/stateHistoryPlugin.ts
@@ -2,6 +2,7 @@ import { BehaviorSubject, distinctUntilChanged, Observable, pairwise } from 'rxj
 import { logAction } from '../../actions';
 import { isFunction } from '../../isFunction';
 import { AkitaPlugin, Queries } from '../plugin';
+import { EntityState } from '../../types';
 
 export interface StateHistoryParams {
   maxAge?: number;
@@ -15,7 +16,7 @@ export type History<State> = {
   future: State[];
 };
 
-export class StateHistoryPlugin<State = any> extends AkitaPlugin<State> {
+export class StateHistoryPlugin<State extends EntityState = any> extends AkitaPlugin<State> {
   /** Allow skipping an update from outside */
   private skip = false;
 

--- a/packages/akita/src/lib/queryEntity.ts
+++ b/packages/akita/src/lib/queryEntity.ts
@@ -397,7 +397,7 @@ export class QueryEntity<S extends EntityState, EntityType = getEntityType<S>, I
 }
 
 // @internal
-export class EntityUIQuery<UIState, DEPRECATED = any> extends QueryEntity<UIState> {
+export class EntityUIQuery<UIState extends EntityState, DEPRECATED = any> extends QueryEntity<UIState> {
   constructor(store) {
     super(store);
   }

--- a/packages/akita/src/lib/runStoreAction.ts
+++ b/packages/akita/src/lib/runStoreAction.ts
@@ -4,7 +4,7 @@ import { isNil } from './isNil';
 import { Store } from './store';
 import { configKey } from './storeConfig';
 import { __stores__ } from './stores';
-import { Constructor } from './types';
+import { Constructor, EntityState } from './types';
 
 export enum StoreAction {
   Update = 'UPDATE',
@@ -60,7 +60,7 @@ export function getStoreByName<TStore extends Store<S>, S = TStore extends Store
  * Get a {@link EntityStore} from the global store registry.
  * @param storeClass The {@link EntityStore} class of the instance to be returned.
  */
-export function getEntityStore<TEntityStore extends EntityStore<S>, S = TEntityStore extends EntityStore<infer T> ? T : never>(storeClass: Constructor<TEntityStore>): TEntityStore {
+export function getEntityStore<TEntityStore extends EntityStore<S>, S extends EntityState = TEntityStore extends EntityStore<infer T> ? T : never>(storeClass: Constructor<TEntityStore>): TEntityStore {
   return getStore(storeClass as Constructor<Store<S>>) as TEntityStore;
 }
 
@@ -68,7 +68,7 @@ export function getEntityStore<TEntityStore extends EntityStore<S>, S = TEntityS
  * Get a {@link EntityStore} from the global store registry.
  * @param storeName The {@link EntityStore} name of the instance to be returned.
  */
-export function getEntityStoreByName<TEntityStore extends EntityStore<S>, S = TEntityStore extends EntityStore<infer T> ? T : never>(storeName: string): TEntityStore {
+export function getEntityStoreByName<TEntityStore extends EntityStore<S>, S extends EntityState = TEntityStore extends EntityStore<infer T> ? T : never>(storeName: string): TEntityStore {
   return getStoreByName<TEntityStore, S>(storeName) as TEntityStore;
 }
 
@@ -106,7 +106,7 @@ export function runStoreAction<TStore extends Store<S>, S = TStore extends Store
  *  runEntityStoreAction(BooksStore, EntityStoreAction.SetEntities, set => set([{ id: 1 }, { id: 2 }]));
  *
  */
-export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TEntityStore extends EntityStore<infer T> ? T : any>(
+export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S extends EntityState = TEntityStore extends EntityStore<infer T> ? T : any>(
   storeClassOrName: Constructor<TEntityStore> | string,
   action: EntityStoreAction.SetEntities,
   operation: (operator: TEntityStore['set']) => void
@@ -121,7 +121,7 @@ export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TE
  *  runEntityStoreAction(BooksStore, EntityStoreAction.AddEntities, add => add({ id: 1 }));
  *
  */
-export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TEntityStore extends EntityStore<infer T> ? T : any>(
+export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S extends EntityState = TEntityStore extends EntityStore<infer T> ? T : any>(
   storeClassOrName: Constructor<TEntityStore> | string,
   action: EntityStoreAction.AddEntities,
   operation: (operator: TEntityStore['add']) => void
@@ -136,7 +136,7 @@ export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TE
  *  runEntityStoreAction(BooksStore, EntityStoreAction.UpdateEntities, update => update(2, { title: 'New title' }));
  *
  */
-export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TEntityStore extends EntityStore<infer T> ? T : any>(
+export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S extends EntityState = TEntityStore extends EntityStore<infer T> ? T : any>(
   storeClassOrName: Constructor<TEntityStore> | string,
   action: EntityStoreAction.UpdateEntities,
   operation: (operator: TEntityStore['update']) => void
@@ -151,7 +151,7 @@ export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TE
  *  runEntityStoreAction(BooksStore, EntityStoreAction.RemoveEntities, remove => remove(2));
  *
  */
-export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TEntityStore extends EntityStore<infer T> ? T : any>(
+export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S extends EntityState = TEntityStore extends EntityStore<infer T> ? T : any>(
   storeClassOrName: Constructor<TEntityStore> | string,
   action: EntityStoreAction.RemoveEntities,
   operation: (operator: TEntityStore['remove']) => void
@@ -166,7 +166,7 @@ export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TE
  *  runEntityStoreAction(BooksStore, EntityStoreAction.UpsertEntities, upsert => upsert([2, 3], { title: 'New Title' }, (id, newState) => ({ id, ...newState, price: 0 })));
  *
  */
-export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TEntityStore extends EntityStore<infer T> ? T : any>(
+export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S extends EntityState = TEntityStore extends EntityStore<infer T> ? T : any>(
   storeClassOrName: Constructor<TEntityStore> | string,
   action: EntityStoreAction.UpsertEntities,
   operation: (operator: TEntityStore['upsert']) => void
@@ -183,12 +183,12 @@ export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TE
  *    { id: 4, title: 'Another title', price: 0 },
  *  ));
  */
-export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TEntityStore extends EntityStore<infer T> ? T : any>(
+export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S extends EntityState = TEntityStore extends EntityStore<infer T> ? T : any>(
   storeClassOrName: Constructor<TEntityStore> | string,
   action: EntityStoreAction.UpsertManyEntities,
   operation: (operator: TEntityStore['upsertMany']) => void
 );
-export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S = TEntityStore extends EntityStore<infer T> ? T : any>(
+export function runEntityStoreAction<TEntityStore extends EntityStore<S>, S extends EntityState = TEntityStore extends EntityStore<infer T> ? T : any>(
   storeClassOrName: Constructor<TEntityStore> | string,
   action: EntityStoreAction,
   operation: (operator: TEntityStore[keyof TEntityStore] & Function) => void


### PR DESCRIPTION
This PR makes the public API of Akita to be consumable in a strict typescript project (and without skipLibCheck).

Refs: salesforce/akita#870

----

The first thing I've tried is to enable `strict: true` for this monorepo and fix them - but the amount of errors in such case is pretty significant 🥵

After that, I tried to fix only TS errors that I found while consuming akita@8.0.0 in my project. And such approach helped me to decrease the API surface to a couple of places, which was somehow fixed in this draft/spike #1050. 

Interestingly, #1050 already allowed me to consume akita in Angular 15 project with a strict mode (and without skipLibCheck).

But unfortunately:
~~1. I'm not confident in these TS-related changes (don't have a big project to test on)~~
**UPD: @qnku @nunoarruda confirmed that it works for them** 
~~2. I want to find a proper tsconfig configuration that will help with the reproduction of the initial issue for future contributors~~
**UPD: I'm thinking of converting `ng-playground` into strict mode and switching it to consume a lib from `dist` (the last one does not oblige us to fix all akita strict issues but only d.ts related) as a separate PR**

But any recommendations on these 2 subjects are welcome!

Also, I'm totally ok if someone wants to use my spike to fix this issue ❤️ 
