### PR TITLE
refactor(general): use relative import

### DIFF
--- a/packages/akita/src/__tests__/env.spec.ts
+++ b/packages/akita/src/__tests__/env.spec.ts
@@ -1,4 +1,4 @@
-import { enableAkitaProdMode } from '@datorama/akita';
+import { enableAkitaProdMode } from '../lib/env';
 
 // isBrowser expression has to be mocked because
 // in context of enableAkitaProdMode func it evaluates


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

```
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?

The issue can be experienced only when switching your tsconfig.base paths to use `dist` instead of `src` (that is what I have tried to do in this repo while working on #1050), because in such case `jest` will not be able to import it (so this test fails)

## What is the new behavior?

Using relative paths within the same project prevents circular self-dependency

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
