### PR TITLE
fix(akita): exclude tests from npm package

### DIFF
--- a/packages/akita/jest.config.ts
+++ b/packages/akita/jest.config.ts
@@ -10,9 +10,9 @@ export default {
   },
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.[tj]sx?$': 'ts-jest',
+    '^.+\\.[tj]s?$': 'ts-jest',
   },
 
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  moduleFileExtensions: ['ts', 'js'],
   coverageDirectory: '../../coverage/packages/akita',
 };

--- a/packages/akita/tsconfig.lib.json
+++ b/packages/akita/tsconfig.lib.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "types": []
   },
-  "include": ["**/*.ts"],
-  "exclude": ["**/*.spec.ts", "jest.config.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/__tests__"]
 }

--- a/packages/akita/tsconfig.spec.json
+++ b/packages/akita/tsconfig.spec.json
@@ -5,5 +5,5 @@
     "module": "commonjs",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx", "**/*.spec.tsx", "**/*.test.js", "**/*.spec.js", "**/*.test.jsx", "**/*.spec.jsx", "**/*.d.ts", "jest.config.ts"]
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
```

## What is the current behavior?

Currently, akita is bundled with its tests so npm package contains them too https://unpkg.com/browse/@datorama/akita@8.0.0/src/

## What is the new behavior?

This change excludes `src/__tests__` from tsc compilation so there is less compiled code in a dist

![image](https://user-images.githubusercontent.com/1770529/218334120-2b7d2907-c7eb-470d-880c-40be61e50b1d.png)

Also includes other minor changes that were replicated from a newly generated lib

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
